### PR TITLE
feat: implement APIs for todo

### DIFF
--- a/src/controllers/api.controller.ts
+++ b/src/controllers/api.controller.ts
@@ -1,9 +1,11 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 
 import { healthRouter } from './health.controller';
+import { todoRouter } from './todo.controller';
 
 const unprotectedApiRouter = new OpenAPIHono();
 unprotectedApiRouter.route('/', healthRouter);
+unprotectedApiRouter.route('/', todoRouter);
 
 const protectedApiRouter = new OpenAPIHono();
 

--- a/src/controllers/todo.controller.ts
+++ b/src/controllers/todo.controller.ts
@@ -1,0 +1,70 @@
+import { todo } from 'node:test';
+import { db } from '~/db/drizzle';
+import { getTodoById, getTodoList, createTodo, updateTodo, deleteTodo } from '~/repositories/todo.repository';
+import { getTodoListRoute, getTodoRoute, createTodoRoute, updateTodoRoute, deleteTodoRoute } from '~/routes/todo.route';
+import { createRouter } from '~/utils/router-factory';
+
+export const todoRouter = createRouter();
+
+// GET /api/todo
+todoRouter.openapi(getTodoListRoute, async (c) => {
+  const q = c.req.valid('query');
+  const todos = await getTodoList(db, q);
+
+  return c.json(todos, 200);
+});
+
+// GET /api/todo/{id}
+todoRouter.openapi(getTodoRoute, async (c) => {
+  const { id } = c.req.valid('param');
+  const todo = await getTodoById(db, id);
+
+  if (!todo) {
+    return c.json({ error: 'Todo not found' }, 404);
+  }
+
+  return c.json(todo, 200);
+});
+
+// POST /api/todo
+todoRouter.openapi(createTodoRoute, async (c) => {
+  const body = c.req.valid('json');
+  const newTodo = await createTodo(db, body);
+
+  return c.json(newTodo, 201);
+});
+
+// PATCH /api/todo/{id}
+todoRouter.openapi(updateTodoRoute, async (c) => {
+  const { id } = c.req.valid('param');
+  const body = c.req.valid('json');
+  
+  const existingTodo = await getTodoById(db, id);
+  if (!existingTodo) {
+    return c.json({ error: 'Todo not found' }, 404);
+  }
+  
+  const updatedTodo = await updateTodo(db, id, body);
+  if (!updatedTodo) {
+    return c.json({ error: 'Failed to update todo' }, 500);
+  }
+  
+  return c.json(updatedTodo, 200);
+});
+
+// DELETE /api/todo/{id}
+todoRouter.openapi(deleteTodoRoute, async (c) => {
+  const { id } = c.req.valid('param');
+
+  const existingTodo = await getTodoById(db, id);
+  if (!existingTodo) {
+    return c.json({ error: 'Todo not found' }, 404);
+  }
+
+  const deletedTodo = await deleteTodo(db, id);
+  if (!deletedTodo) {
+    return c.json({ error: 'Failed to delete todo' }, 500);
+  }
+
+  return c.body(null, 204);
+});

--- a/src/repositories/todo.repository.ts
+++ b/src/repositories/todo.repository.ts
@@ -1,0 +1,83 @@
+import { eq } from 'drizzle-orm';
+import type z from 'zod';
+import type { Database } from '~/db/drizzle';
+import { first } from '~/db/helper';
+import { todo } from '~/db/schema/todo.schema';
+import type { GetTodoListQuerySchema, CreateTodoSchema, UpdateTodoSchema } from '~/types/todo.type';
+import { createId, getNow } from '~/utils/drizzle-schema-util';
+
+export const getTodoList = async (
+  db: Database,
+  q: z.infer<typeof GetTodoListQuerySchema>,
+) => {
+  if (q.isCompleted === undefined) {
+    return db.select().from(todo);
+  }
+
+  const isCompleted =
+    q.isCompleted === 'true'
+      ? eq(todo.isCompleted, true)
+      : eq(todo.isCompleted, false);
+
+  return db.select().from(todo).where(isCompleted);
+};
+
+export const getTodoById = async (db: Database, id: string) => {
+  return db.select().from(todo).where(eq(todo.id, id)).then(first);
+};
+
+export const createTodo = async (
+  db: Database,
+  body: z.infer<typeof CreateTodoSchema>,
+) => {
+  const newTodo = {
+    id: createId(),
+    title: body.title,
+    description: body.description || '',
+    isCompleted: false,
+    createdAt: getNow(),
+    updatedAt: getNow(),
+  };
+
+  return db.insert(todo).values(newTodo).returning().then(first);
+};
+
+export const updateTodo = async (
+  db: Database,
+  id: string,
+  body: z.infer<typeof UpdateTodoSchema>,
+) => {
+  const updateData: Partial<{
+    title: string;
+    description: string;
+    isCompleted: boolean;
+    updatedAt: Date;
+  }> = {
+    updatedAt: getNow(),
+  };
+
+  if (body.title !== null && body.title !== undefined) {
+    updateData.title = body.title;
+  }
+  if (body.description !== null && body.description !== undefined) {
+    updateData.description = body.description;
+  }
+  if (body.isCompleted !== null && body.isCompleted !== undefined) {
+    updateData.isCompleted = body.isCompleted;
+  }
+
+  return db
+    .update(todo)
+    .set(updateData)
+    .where(eq(todo.id, id))
+    .returning()
+    .then(first);
+};
+
+export const deleteTodo = async (db: Database, id: string) => {
+  return db
+    .delete(todo)
+    .where(eq(todo.id, id))
+    .returning()
+    .then(first);
+};

--- a/src/routes/todo.route.ts
+++ b/src/routes/todo.route.ts
@@ -1,0 +1,137 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import {
+  GetTodoListQuerySchema,
+  GetTodoParamsSchema,
+  TodoListSchema,
+  TodoSchema,
+  CreateTodoSchema,
+  UpdateTodoSchema,
+} from '~/types/todo.type';
+import { createErrorResponse } from '~/utils/error-response-factory';
+
+export const getTodoListRoute = createRoute({
+  operationId: 'getTodoList',
+  tags: ['todo'],
+  method: 'get',
+  path: '/todo',
+  request: {
+    query: GetTodoListQuerySchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: TodoListSchema,
+        },
+      },
+      description: 'Get the list of todos',
+    },
+    400: createErrorResponse('UNION', 'Bad request error'),
+    401: createErrorResponse('GENERIC', 'Unauthorized'),
+    404: createErrorResponse('GENERIC', 'Not found'),
+    500: createErrorResponse('GENERIC', 'Internal server error'),
+  },
+});
+
+export const getTodoRoute = createRoute({
+  operationId: 'getTodo',
+  tags: ['todo'],
+  method: 'get',
+  path: '/todo/{id}',
+  request: {
+    params: GetTodoParamsSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: TodoSchema,
+        },
+      },
+      description: 'Get a todo by ID',
+    },
+    400: createErrorResponse('UNION', 'Bad request error'),
+    401: createErrorResponse('GENERIC', 'Unauthorized'),
+    404: createErrorResponse('GENERIC', 'Not found'),
+    500: createErrorResponse('GENERIC', 'Internal server error'),
+  },
+});
+
+export const createTodoRoute = createRoute({
+  operationId: 'createTodo',
+  tags: ['todo'],
+  method: 'post',
+  path: '/todo',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateTodoSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        'application/json': {
+          schema: TodoSchema,
+        },
+      },
+      description: 'Create a new todo',
+    },
+    400: createErrorResponse('UNION', 'Bad request error'),
+    401: createErrorResponse('GENERIC', 'Unauthorized'),
+    500: createErrorResponse('GENERIC', 'Internal server error'),
+  },
+});
+
+export const updateTodoRoute = createRoute({
+  operationId: 'updateTodo',
+  tags: ['todo'],
+  method: 'patch',
+  path: '/todo/{id}',
+  request: {
+    params: GetTodoParamsSchema,
+    body: {
+      content: {
+        'application/json': {
+          schema: UpdateTodoSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: TodoSchema,
+        },
+      },
+      description: 'Update a todo by ID',
+    },
+    400: createErrorResponse('UNION', 'Bad request error'),
+    401: createErrorResponse('GENERIC', 'Unauthorized'),
+    404: createErrorResponse('GENERIC', 'Not found'),
+    500: createErrorResponse('GENERIC', 'Internal server error'),
+  },
+});
+
+export const deleteTodoRoute = createRoute({
+  operationId: 'deleteTodo',
+  tags: ['todo'],
+  method: 'delete',
+  path: '/todo/{id}',
+  request: {
+    params: GetTodoParamsSchema,
+  },
+  responses: {
+    204: {
+      description: 'Delete a todo by ID',
+    },
+    400: createErrorResponse('UNION', 'Bad request error'),
+    401: createErrorResponse('GENERIC', 'Unauthorized'),
+    404: createErrorResponse('GENERIC', 'Not found'),
+    500: createErrorResponse('GENERIC', 'Internal server error'),
+  },
+});

--- a/src/types/todo.type.ts
+++ b/src/types/todo.type.ts
@@ -1,0 +1,31 @@
+import z from 'zod';
+
+export const TodoSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  description: z.string(),
+  isCompleted: z.boolean(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const TodoListSchema = z.array(TodoSchema);
+
+export const GetTodoListQuerySchema = z.object({
+  isCompleted: z.enum(['true', 'false']).optional(),
+});
+
+export const GetTodoParamsSchema = z.object({
+  id: z.string(),
+});
+
+export const CreateTodoSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().optional(),
+});
+
+export const UpdateTodoSchema = z.object({
+  title: z.string().min(1, 'Title is required').optional(),
+  description: z.string().optional(),
+  isCompleted: z.boolean().optional(),
+});


### PR DESCRIPTION
Handle CRUD operations for todo.

The following endpoints have been added:
- GET /api/todo
- GET /api/todo/{id}
- POST /api/todo
- PATCH /api/todo/{id}
- DELETE /api/todo/{id}